### PR TITLE
Release 0.1.1 -- add propagate_tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,5 +65,6 @@ resource "aws_cloudwatch_event_target" "this" {
     task_count          = 1
     launch_type         = "EC2"
     task_definition_arn = var.task_definition_arn
+    propagate_tags      = "TASK_DEFINITION"
   }
 }


### PR DESCRIPTION
### Added
- Added `propagate_tags`. It seems this is always assumed even if not specified. Each plan produces a desired change that does not seem to be effective.
