### PR TITLE
Release 0.1.2 -- add validation for name variable to avoid length errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "random_id" "name_suffix" {
 }
 
 resource "aws_iam_role" "this" {
-  name = "ecs_events-${local.unique_name}"
+  name = "events-${local.unique_name}"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/test/main.tf
+++ b/test/main.tf
@@ -2,22 +2,22 @@
 module "minimal" {
   source = "../"
 
-  ecs_cluster_arn     = ""
-  task_definition_arn = ""
-  name                = ""
+  ecs_cluster_arn     = "arn:aws:ecs:us-east-1:000000000000:cluster/test-cluster"
+  task_definition_arn = "arn:aws:ecs:us-east-1:000000000000:task-definition/test-td:1"
+  name                = "test-name"
 }
 
 module "full" {
   source = "../"
 
-  ecs_cluster_arn        = "a"
-  task_definition_arn    = "b"
-  name                   = "c"
-  event_schedule         = "d"
+  ecs_cluster_arn        = "arn:aws:ecs:us-east-1:000000000000:cluster/test-cluster"
+  task_definition_arn    = "arn:aws:ecs:us-east-1:000000000000:task-definition/test-td:1"
+  name                   = "0123456789abcdef0123456789abcdef0123456789abcdef"
+  event_schedule         = "cron(0 0 1 1 ? 1)"
   enable                 = true
-  event_rule_description = "e"
-  event_target_input     = "f"
-  tags                   = { g : "h" }
+  event_rule_description = "a description"
+  event_target_input     = jsonencode({ "containerOverrides" : [{ "name" : "container_name", "command" : ["true"] }] })
+  tags                   = { tag_name : "tag_value" }
 }
 
 output "an_output" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "task_definition_arn" {
 variable "name" {
   description = "name of event assigned to "
   type        = string
+
+  validation {
+    condition     = length(var.name) <= 48
+    error_message = "The variable 'name' must be at most 48 characters to avoid exceeding the aws_iam_role name limit of 64 characters."
+  }
 }
 
 variable "event_schedule" {


### PR DESCRIPTION
### Added
- Added validation on var.name

### Changed
- Changed the aws_iam_role name prefix to help alleviate aws_iam_role name length limitation.
