### PR TITLE
make the task_definition_arn variable more flexible

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role_policy" "this" {
       {
         Effect   = "Allow"
         Action   = "ecs:RunTask"
-        Resource = replace(var.task_definition_arn, "/:\\d+$/", ":*")
+        Resource = "${replace(var.task_definition_arn, "/:\\d+$/", "")}:*"
       },
     ]
   })


### PR DESCRIPTION
Strip any task definition version, if provided, then add ":*" to the end. This should work whether the variable has an asterisk, a number, or neither.
