### PR TITLE
restrict the iam:PassRole statement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,11 @@ resource "aws_iam_role_policy" "this" {
         Effect   = "Allow"
         Action   = "ecs:RunTask"
         Resource = "${data.aws_ecs_task_definition.this.arn_without_revision}:*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
       },
     ]
   })

--- a/main.tf
+++ b/main.tf
@@ -35,10 +35,10 @@ resource "aws_iam_role_policy" "this" {
       {
         Effect   = "Allow"
         Action   = "iam:PassRole"
-        Resource = compact([
+        Resource = [for arn in [
           data.aws_ecs_task_definition.this.task_role_arn,
           data.aws_ecs_task_definition.this.execution_role_arn,
-        ])
+        ] : arn if arn != null && arn != ""]
         Condition = {
           StringEquals = {
             "iam:PassedToService" = "ecs-tasks.amazonaws.com"

--- a/main.tf
+++ b/main.tf
@@ -33,12 +33,12 @@ resource "aws_iam_role_policy" "this" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = "iam:PassRole"
-        Resource = [for arn in [
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = compact([
           data.aws_ecs_task_definition.this.task_role_arn,
           data.aws_ecs_task_definition.this.execution_role_arn,
-        ] : arn if arn != null && arn != ""]
+        ])
         Condition = {
           StringEquals = {
             "iam:PassedToService" = "ecs-tasks.amazonaws.com"

--- a/main.tf
+++ b/main.tf
@@ -33,12 +33,17 @@ resource "aws_iam_role_policy" "this" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = "iam:PassRole"
-        Resource = [
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = compact([
           data.aws_ecs_task_definition.this.task_role_arn,
           data.aws_ecs_task_definition.this.execution_role_arn,
-        ]
+        ])
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
       },
       {
         Effect   = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,14 @@
 
 locals {
   unique_name = "${var.name}-${random_id.name_suffix.b64_url}"
+  pass_role_resources = compact([
+    data.aws_ecs_task_definition.this.task_role_arn,
+    data.aws_ecs_task_definition.this.execution_role_arn,
+  ])
+}
+
+data "aws_ecs_task_definition" "this" {
+  task_definition = var.task_definition_arn
 }
 
 resource "random_id" "name_suffix" {
@@ -29,38 +37,37 @@ resource "aws_iam_role_policy" "this" {
   name = "ecs_events_run_task_with_any_role"
   role = aws_iam_role.this.id
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = "iam:PassRole"
-        Resource = compact([
-          data.aws_ecs_task_definition.this.task_role_arn,
-          data.aws_ecs_task_definition.this.execution_role_arn,
-        ])
-        Condition = {
-          StringEquals = {
-            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
-          }
-        }
-      },
-      {
-        Effect   = "Allow"
-        Action   = "ecs:RunTask"
-        Resource = "${data.aws_ecs_task_definition.this.arn_without_revision}:*"
-        Condition = {
-          ArnEquals = {
-            "ecs:cluster" = var.ecs_cluster_arn
-          }
-        }
-      },
-    ]
-  })
+  policy = data.aws_iam_policy_document.this.json
 }
 
-data "aws_ecs_task_definition" "this" {
-  task_definition = var.task_definition_arn
+data "aws_iam_policy_document" "this" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ecs:RunTask"]
+    resources = ["${data.aws_ecs_task_definition.this.arn_without_revision}:*"]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "ecs:cluster"
+      values   = [var.ecs_cluster_arn]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(local.pass_role_resources) > 0 ? [1] : []
+
+    content {
+      effect    = "Allow"
+      actions   = ["iam:PassRole"]
+      resources = local.pass_role_resources
+
+      condition {
+        test     = "StringEquals"
+        variable = "iam:PassedToService"
+        values   = ["ecs-tasks.amazonaws.com"]
+      }
+    }
+  }
 }
 
 resource "aws_cloudwatch_event_rule" "this" {

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,6 @@ resource "aws_iam_role" "this" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = ""
         Effect = "Allow"
         Principal = {
           Service = "events.amazonaws.com"

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy" "this" {
-  name = "ecs_events_run_task_with_any_role"
+  name = "run_task"
   role = aws_iam_role.this.id
 
   policy = data.aws_iam_policy_document.this.json

--- a/main.tf
+++ b/main.tf
@@ -33,17 +33,24 @@ resource "aws_iam_role_policy" "this" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = "iam:PassRole"
-        Resource = "*"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          data.aws_ecs_task_definition.this.task_role_arn,
+          data.aws_ecs_task_definition.this.execution_role_arn,
+        ]
       },
       {
         Effect   = "Allow"
         Action   = "ecs:RunTask"
-        Resource = "${replace(var.task_definition_arn, "/:\\d+$/", "")}:*"
+        Resource = "${data.aws_ecs_task_definition.this.arn_without_revision}:*"
       },
     ]
   })
+}
+
+data "aws_ecs_task_definition" "this" {
+  task_definition = var.task_definition_arn
 }
 
 resource "aws_cloudwatch_event_rule" "this" {


### PR DESCRIPTION
[ITSE-2843](https://support.gtis.sil.org/issue/ITSE-2843) Restrict roles on all iam:PassRole policies

---

### Security
- Restrict the `iam:PassRole` statement to only the task role and task execution role.
